### PR TITLE
Add measure target for key-value

### DIFF
--- a/C++/key-value/Makefile
+++ b/C++/key-value/Makefile
@@ -15,3 +15,12 @@ run:
 		--server-command "./key_value.o 127.0.0.1 51234 24576 1024" \
 		--client-command "redis-benchmark -c $(JOBS) -n 2000000 -d 64 -r 500000 -t set,get -h 127.0.0.1 -p 51234" \
 		--ready-matcher ".* initialized"
+
+measure:
+ifndef JSON
+	$(error JSON is not defined)
+endif
+	sudo ../../scripts/RAPL/build/rapl "$(JSON)" python3 ../../data/run-server-client.py \
+		--server-command "./key_value.o 127.0.0.1 51234 24576 1024" \
+		--client-command "redis-benchmark -c $(JOBS) -n 2000000 -d 64 -r 500000 -t set,get -h 127.0.0.1 -p 51234" \
+		--ready-matcher ".* initialized"

--- a/Go/key-value/Makefile
+++ b/Go/key-value/Makefile
@@ -17,3 +17,12 @@ run:
 		--server-command "./key_value.o 127.0.0.1 51234 24576 1024" \
 		--client-command "redis-benchmark -c $(JOBS) -n 2000000 -d 64 -r 500000 -t set,get -h 127.0.0.1 -p 51234" \
 		--ready-matcher ".* initialized"
+
+measure:
+ifndef JSON
+	$(error JSON is not defined)
+endif
+	sudo ../../scripts/RAPL/build/rapl "$(JSON)" python3 ../../data/run-server-client.py \
+		--server-command "./key_value.o 127.0.0.1 51234 24576 1024" \
+		--client-command "redis-benchmark -c $(JOBS) -n 2000000 -d 64 -r 500000 -t set,get -h 127.0.0.1 -p 51234" \
+		--ready-matcher ".* initialized"

--- a/Java/key-value/Makefile
+++ b/Java/key-value/Makefile
@@ -21,3 +21,12 @@ run:
 		--server-command "$(JAVA) KeyValue 127.0.0.1 51234 24576 1024" \
 		--client-command "redis-benchmark -c $(JOBS) -n 2000000 -d 64 -r 500000 -t set,get -h 127.0.0.1 -p 51234" \
 		--ready-matcher ".* initialized"
+
+measure:
+ifndef JSON
+	$(error JSON is not defined)
+endif
+	sudo ../../scripts/RAPL/build/rapl "$(JSON)" python3 ../../data/run-server-client.py \
+		--server-command "$(JAVA) KeyValue 127.0.0.1 51234 24576 1024" \
+		--client-command "redis-benchmark -c $(JOBS) -n 2000000 -d 64 -r 500000 -t set,get -h 127.0.0.1 -p 51234" \
+		--ready-matcher ".* initialized"

--- a/JavaScript/key-value/Makefile
+++ b/JavaScript/key-value/Makefile
@@ -16,3 +16,12 @@ run:
 		--server-command "$(NODE) key_value.js 127.0.0.1 51234 24576 1024" \
 		--client-command "redis-benchmark -c $(JOBS) -n 2000000 -d 64 -r 500000 -t set,get -h 127.0.0.1 -p 51234" \
 		--ready-matcher ".* initialized"
+
+measure:
+ifndef JSON
+	$(error JSON is not defined)
+endif
+	sudo ../../scripts/RAPL/build/rapl "$(JSON)" python3 ../../data/run-server-client.py \
+		--server-command "$(NODE) key_value.js 127.0.0.1 51234 24576 1024" \
+		--client-command "redis-benchmark -c $(JOBS) -n 2000000 -d 64 -r 500000 -t set,get -h 127.0.0.1 -p 51234" \
+		--ready-matcher ".* initialized"

--- a/Python/key-value/Makefile
+++ b/Python/key-value/Makefile
@@ -16,3 +16,12 @@ run:
 		--server-command "$(PYTHON) key_value.py 127.0.0.1 51234 24576 1024" \
 		--client-command "redis-benchmark -c $(JOBS) -n 2000000 -d 64 -r 500000 -t set,get -h 127.0.0.1 -p 51234" \
 		--ready-matcher ".* initialized"
+
+measure:
+ifndef JSON
+	$(error JSON is not defined)
+endif
+	sudo ../../scripts/RAPL/build/rapl "$(JSON)" python3 ../../data/run-server-client.py \
+		--server-command "$(PYTHON) key_value.py 127.0.0.1 51234 24576 1024" \
+		--client-command "redis-benchmark -c $(JOBS) -n 2000000 -d 64 -r 500000 -t set,get -h 127.0.0.1 -p 51234" \
+		--ready-matcher ".* initialized"


### PR DESCRIPTION
Context:
 -  8107cb422e1d94d48b011e4cc101b1a84a795ebc: Server now prints a message when ready.
 -  4260530254b3b9b9f53ab06e729fe69271b2e4ac: Python script instead of `screen`.

~@dungwinux Could you please do the same thing for `file-server`?~

Also, we should make sure at some point we use the same concurrency level for all languages, not sure that's the case. Sometimes the original authors had several versions of the benchmark, with/without concurrency.